### PR TITLE
Unit Tests; Cleanup; Initialization Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,14 @@ buildscript {
         jcenter()
         google()
         mavenCentral()
-        maven { url "" }
+        mavenLocal()
+        maven { url "https://maven.tozny.com/repo" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta6'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.0.0"
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.7.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }
 }
 

--- a/e3db-crypto-android/build.gradle
+++ b/e3db-crypto-android/build.gradle
@@ -32,6 +32,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.0'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
     compileOnly project(':e3db-crypto-interface')
-    compile 'com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:1.0.6'
+    compile 'com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:1.0.7'
 }
 

--- a/e3dbtest/build.gradle
+++ b/e3dbtest/build.gradle
@@ -33,24 +33,18 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.0.1'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
 
-    compile project(path: ':e3db')
-    compile 'commons-io:commons-io:2.5'
-
     androidTestCompile 'com.android.support.test:runner:1.0.1'
     androidTestCompile 'com.android.support.test:rules:1.0.1'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr4'
+    androidTestImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr4'
+    androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.0.pr4'
+
+    androidTestCompile project(path: ':e3db')
     androidTestCompile project(path: ':e3db-crypto-android')
-
-    // To match version in e3db library.
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr4'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.0.pr4'
-
-    compile project(path: ':e3db')
-    compile project(path: ':e3db-crypto-android')
-    compile 'commons-io:commons-io:2.5'
 
     testImplementation junit5()
     testCompileOnly "de.mannodermaus.gradle.plugins:android-junit5-embedded-runtime:1.0.0"
+    testCompile project(path: ':e3db')
     testCompile project(path: ':e3db-crypto-plain')
 }

--- a/e3dbtest/src/main/java/com/tozny/e3dbtest/MainActivity.java
+++ b/e3dbtest/src/main/java/com/tozny/e3dbtest/MainActivity.java
@@ -1,0 +1,28 @@
+package com.tozny.e3dbtest;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MainActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+  }
+}

--- a/publish/android/build.gradle
+++ b/publish/android/build.gradle
@@ -78,5 +78,5 @@ dependencies {
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr4'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.0.pr4'
   compile 'com.squareup.okio:okio:1.13.0'
-  compile 'com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:1.0.6'
+  compile 'com.github.joshjdevl.libsodiumjni:libsodium-jni-aar:1.0.7'
 }

--- a/publish/plain/build.gradle
+++ b/publish/plain/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 sourceSets {
   main {


### PR DESCRIPTION
* Update AndroidCrypto to ensure libsodium initialization always
  runs.
* Roll to latest android libsodium
* Add required (empty) activity to android test app.