### PR TITLE
Better mocking support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -117,6 +117,27 @@ The published artifacts have different names, but should share versions. They ar
 
 (The version is specified in the file `./publish/build.gradle`.)
 
+To publish to Tozny's Maven repository, the following environemt variables must be set:
+
+* `REPO_URL` - URL for the S3 bucket holding maven artifacts (in the form `s3://.../repo`).
+* `AWS_KEY` - Your AWS API key.
+* `AWS_SECRET` - Your AWS API secret.
+
+The version published is set in the file at `publish/build.gradle`.
+
+Assuming your account has the correct privileges, publish by running the following two tasks. First, to
+publish an Android AAR:
+
+```bash
+$ ./gradlew :publish:android:publishMavenPublicationToMavenRepository
+```
+
+and to publish a Plain Java JAR:
+
+```
+$ ./gradlew :publish:plain:publishMavenPublicationToMavenRepository
+```
+
 Writing Android Apps
 ====
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,15 +54,15 @@ Android Testing
 
 The `androidtest` project contains Android-specific tests (for crypto operations as well as secure configuration storage).
 
-You can run the Android tests from the command line using the command `gradlew :androidtest:connectedAndroidTest`, assuming a phone is
-plugged in and has USB debugging enabled.
+You can run instrumented Android tests from the command line using the command `gradlew :androidtest:connectedAndroidTest`, using an
+emulator or connected phone. Unit tests can be run using the command `gradlew :androidtest:test`.
 
 The `androidtest` project also contain an app which exercises all secure configuration storage options. You can register
 a client and protect the generated configuration with a password, lock screen PIN, fingerprint, or not at all (depending
 on API level of the device, of course). The app is not intended to be used as an automated test, but as a tool for manual
 testing.
 
-Note that to run the app, you must publish the SDK locally
+Note that to run the app, you must publish the SDK locally.
 
 Running a Subset of Tests
 ----

--- a/androidtest/build.gradle
+++ b/androidtest/build.gradle
@@ -61,6 +61,12 @@ dependencies {
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr4'
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.0.pr4'
 
+    // Required -- JUnit 4 framework
+    testImplementation 'junit:junit:4.12'
+    // Optional -- Mockito framework
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+
+
     androidTestImplementation project(path: ':e3db')
     androidTestImplementation project(path: ':e3db-crypto-interface')
     androidTestImplementation(project(path: ':e3db-crypto-android'))

--- a/androidtest/src/test/java/com/tozny/e3db/MockTests.java
+++ b/androidtest/src/test/java/com/tozny/e3db/MockTests.java
@@ -1,0 +1,14 @@
+package com.tozny.e3db;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MockTests {
+  @Test
+  public void testClient() {
+    E3DBClient c = mock(E3DBClient.class);
+    assertNotNull(c);
+  }
+}

--- a/androidtest/src/test/java/com/tozny/e3db/MockTests.java
+++ b/androidtest/src/test/java/com/tozny/e3db/MockTests.java
@@ -2,13 +2,27 @@ package com.tozny.e3db;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class MockTests {
   @Test
   public void testClient() {
     E3DBClient c = mock(E3DBClient.class);
     assertNotNull(c);
+  }
+
+  public void testRegistrationClient() {
+    E3DBRegistrationClient r = mock(E3DBRegistrationClient.class);
+    assertNotNull(r);
+
+    E3DBClient c = mock(E3DBClient.class);
+    when(c.registrationClient()).thenReturn(r);
+
+    E3DBRegistrationClient returnedRegClient = c.registrationClient();
+    assertNotNull(returnedRegClient);
+    assertSame(r, returnedRegClient);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         maven { url "https://maven.tozny.com/repo" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.0.0"
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'

--- a/common-test/src/test/java/com/tozny/e3db/ClientTest.java
+++ b/common-test/src/test/java/com/tozny/e3db/ClientTest.java
@@ -27,10 +27,18 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import okhttp3.CertificatePinner;
 import org.junit.*;
 
+import javax.crypto.*;
+import javax.crypto.spec.IvParameterSpec;
+
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,10 +113,10 @@ public class ClientTest {
   }
 
   private static class CI {
-    public final E3DBClient client;
+    public final Client client;
     public final Config clientConfig;
 
-    private CI(E3DBClient client, Config clientConfig) {
+    private CI(Client client, Config clientConfig) {
       this.client = client;
       this.clientConfig = clientConfig;
     }
@@ -148,13 +156,13 @@ public class ClientTest {
 
   private CI getClient(String profile) throws IOException {
     final Config info = Config.fromJson(profiles.get(profile));
-    final E3DBClient client = new ClientBuilder()
+    final Client client = new ClientBuilder()
       .fromConfig(info)
       .build();
     return new CI(client, info);
   }
 
-  private void write1(E3DBClient client, final ResultHandler<Record> handleResult) throws IOException {
+  private void write1(Client client, final ResultHandler<Record> handleResult) throws IOException {
     Map<String, String> record = new HashMap<>();
     record.put(FIELD, MESSAGE);
     client.write(TYPE, new RecordData(record), null, new ResultHandler<Record>() {
@@ -284,7 +292,7 @@ public class ClientTest {
   @Test
   public void testQuery() throws Exception {
     final AtomicReference<UUID> recordId = new AtomicReference<>();
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
     withTimeout(new AsyncAction() {
       @Override
       public void act(CountDownLatch wait) throws Exception {
@@ -337,7 +345,7 @@ public class ClientTest {
 
   @Test
   public void testDelete() throws IOException, InterruptedException {
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
 
     withTimeout(new AsyncAction() {
       @Override
@@ -382,7 +390,7 @@ public class ClientTest {
 
   @Test
   public void testWrite() throws IOException, InterruptedException {
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
     final AtomicReference<UUID> recordId = new AtomicReference<>();
     withTimeout(new AsyncAction() {
       @Override
@@ -422,7 +430,7 @@ public class ClientTest {
 
   @Test
   public void testPaging() throws InterruptedException, IOException {
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
     final AtomicInteger pages = new AtomicInteger(0);
     final AtomicReference<Boolean> done = new AtomicReference<>(false);
     final AtomicLong last = new AtomicLong(-1L);
@@ -484,7 +492,7 @@ public class ClientTest {
 
   @Test
   public void testRecordDataUpdate() throws IOException, InterruptedException {
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
     final String updatedMessage = "Not to put too fine a point on it";
     withTimeout(new AsyncAction() {
       @Override
@@ -515,7 +523,7 @@ public class ClientTest {
 
   @Test
   public void testRecordDataCustomUpdateMetaClass() throws IOException, InterruptedException {
-    final E3DBClient client = getClient().client;
+    final Client client = getClient().client;
     final String updatedMessage = "Not to put too fine a point on it";
     withTimeout(new AsyncAction() {
       @Override
@@ -565,7 +573,7 @@ public class ClientTest {
 
   @Test
   public void testPlaintextMetaUpdate() throws InterruptedException, IOException {
-    final AtomicReference<E3DBClient> clientRef = new AtomicReference<>();
+    final AtomicReference<Client> clientRef = new AtomicReference<>();
     final AtomicReference<Record> recordRef = new AtomicReference<>();
     registerProfile(UUID.randomUUID().toString(), new ResultHandler<Config>() {
       @Override
@@ -855,7 +863,7 @@ public class ClientTest {
 
   @Test
   public void testWritePlain() throws InterruptedException, IOException {
-    final AtomicReference<E3DBClient> clientRef = new AtomicReference<>();
+    final AtomicReference<Client> clientRef = new AtomicReference<>();
     Map<String, String> poem = new HashMap<>();
     poem.put("line", "All mimsy were the borogoves,");
     final RecordData data = new RecordData(poem);
@@ -969,7 +977,7 @@ public class ClientTest {
   @Test
   public void testEncryptDecrypt() throws IOException, E3DBException {
     CI clientInfo = getClient();
-    final E3DBClient client = clientInfo.client;
+    final Client client = clientInfo.client;
     final String type = UUID.randomUUID().toString() + "-type";
     final AtomicReference<EAKInfo> eakInfoRef = new AtomicReference<>();
     withTimeout(new AsyncAction() {
@@ -1013,14 +1021,14 @@ public class ClientTest {
   @Test
   public void testEncryptDecryptTwoClients() throws IOException, E3DBException {
     CI clientInfo1 = getClient();
-    final E3DBClient client1 = clientInfo1.client;
+    final Client client1 = clientInfo1.client;
     final String type = UUID.randomUUID().toString() + "-type";
     final AtomicReference<EAKInfo> writerKeyRef = new AtomicReference<>();
 
     final String client2Name = UUID.randomUUID().toString();
     registerProfile(client2Name, null);
     CI clientInfo2 = getClient(client2Name);
-    final E3DBClient client2 = clientInfo2.client;
+    final Client client2 = clientInfo2.client;
 
     withTimeout(new AsyncAction() {
       @Override
@@ -1090,7 +1098,7 @@ public class ClientTest {
   @Test
   public void testSigning() throws IOException {
     final CI clientInfo1 = getClient();
-    final E3DBClient client = clientInfo1.client;
+    final Client client = clientInfo1.client;
     final String recordType = "lyric";
     final Map<String, String> data = new HashMap<>();
     data.put("Jabberwock", "Not to put too fine a point on it");
@@ -1150,7 +1158,7 @@ public class ClientTest {
   @Test
   public void testExternalEncryptedRecord() throws IOException {
     final CI clientInfo1 = getClient();
-    final E3DBClient client = clientInfo1.client;
+    final Client client = clientInfo1.client;
     final JsonNode extEncryptedRecord = mapper.readTree("{\"doc\":{\"data\":{\"test_field\":\"QWfE7PpAjTgih1E9jyqSGex32ouzu1iF3la8fWNO5wPp48U2F5Q6kK41_8hgymWn.HW-dBzttfU6Xui-o01lOdVqchXJXqfqQ.eo8zE8peRC9qSt2ZOE8_54kOF0bWBEovuZ4.zO56Or0Pu2IFSzQZRpuXLeinTHQl7g9-\"},\"meta\":{\"plain\":{\"client_pub_sig_key\":\"fcyEKo6HSZo9iebWAQnEemVfqpTUzzR0VNBqgJJG-LY\",\"server_sig_of_client_sig_key\":\"ZtmkUb6MJ-1LqpIbJadYl_PPH5JjHXKrBspprhzaD8rKM4ejGD8cJsSFO1DlR-r7u-DKsLUk82EJF65RnTmMDQ\"},\"type\":\"ticket\",\"user_id\":\"d405a1ce-e528-4946-8682-4c2369a26604\",\"writer_id\":\"d405a1ce-e528-4946-8682-4c2369a26604\"},\"rec_sig\":\"YsNbSXy0mVqsvgArmdESe6SkTAWFui8_NBn8ZRyxBfQHmJt7kwDU6szEqiRIaoZGrHsqgwS3uduLo_kzG6UeCA\"},\"sig\":\"iYc7G6ersNurZRr7_lWqoilr8Ve1d6HPZPPyC4YMXSvg7QvpUAHvjv4LsdMMDthk7vsVpoR0LYPC_SkIip7XCw\"}");
     final JsonNode doc = extEncryptedRecord.get("doc");
     final EncryptedRecord record = LocalEncryptedRecord.decode(mapper.writeValueAsString(doc));
@@ -1171,7 +1179,7 @@ public class ClientTest {
   @Test
   public void testEncryptSigning() throws IOException {
     final CI clientInfo1 = getClient();
-    final E3DBClient client = clientInfo1.client;
+    final Client client = clientInfo1.client;
     final String recordType = "lyric";
     final Map<String, String> plain = new HashMap<>();
     plain.put("frabjous", "Filibuster vigilantly");
@@ -1213,7 +1221,7 @@ public class ClientTest {
   @Test
   public void testEncodeDecodeLocal() throws IOException, E3DBException {
     final CI clientInfo1 = getClient();
-    final E3DBClient client = clientInfo1.client;
+    final Client client = clientInfo1.client;
     final String recordType = "signedLyric";
     final AtomicReference<EAKInfo> eak = new AtomicReference<>();
 
@@ -1336,8 +1344,8 @@ public class ClientTest {
 
   @Test
   public void testEncodeDecodeWrite() throws IOException, E3DBException {
-    final AtomicReference<E3DBClient> client1 = new AtomicReference<>();
-    final AtomicReference<E3DBClient> client2 = new AtomicReference<>();
+    final AtomicReference<Client> client1 = new AtomicReference<>();
+    final AtomicReference<Client> client2 = new AtomicReference<>();
     final AtomicReference<EAKInfo> writerEak = new AtomicReference<>();
     final AtomicReference<EAKInfo> readerEak = new AtomicReference<>();
     final String recordType = "signedLyric";
@@ -1492,7 +1500,7 @@ public class ClientTest {
   @Test
   public void testEAK() throws IOException, E3DBException {
     final CI clientInfo1 = getClient();
-    final E3DBClient client = clientInfo1.client;
+    final Client client = clientInfo1.client;
     final String type = UUID.randomUUID().toString();
     final AtomicReference<LocalEAKInfo> info = new AtomicReference<>();
 

--- a/common-test/src/test/java/com/tozny/e3db/ClientTest.java
+++ b/common-test/src/test/java/com/tozny/e3db/ClientTest.java
@@ -27,18 +27,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import okhttp3.CertificatePinner;
 import org.junit.*;
 
-import javax.crypto.*;
-import javax.crypto.spec.IvParameterSpec;
-
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,10 +105,10 @@ public class ClientTest {
   }
 
   private static class CI {
-    public final Client client;
+    public final E3DBClient client;
     public final Config clientConfig;
 
-    private CI(Client client, Config clientConfig) {
+    private CI(E3DBClient client, Config clientConfig) {
       this.client = client;
       this.clientConfig = clientConfig;
     }
@@ -156,13 +148,13 @@ public class ClientTest {
 
   private CI getClient(String profile) throws IOException {
     final Config info = Config.fromJson(profiles.get(profile));
-    final Client client = new ClientBuilder()
+    final E3DBClient client = new ClientBuilder()
       .fromConfig(info)
       .build();
     return new CI(client, info);
   }
 
-  private void write1(Client client, final ResultHandler<Record> handleResult) throws IOException {
+  private void write1(E3DBClient client, final ResultHandler<Record> handleResult) throws IOException {
     Map<String, String> record = new HashMap<>();
     record.put(FIELD, MESSAGE);
     client.write(TYPE, new RecordData(record), null, new ResultHandler<Record>() {
@@ -292,7 +284,7 @@ public class ClientTest {
   @Test
   public void testQuery() throws Exception {
     final AtomicReference<UUID> recordId = new AtomicReference<>();
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
     withTimeout(new AsyncAction() {
       @Override
       public void act(CountDownLatch wait) throws Exception {
@@ -345,7 +337,7 @@ public class ClientTest {
 
   @Test
   public void testDelete() throws IOException, InterruptedException {
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
 
     withTimeout(new AsyncAction() {
       @Override
@@ -390,7 +382,7 @@ public class ClientTest {
 
   @Test
   public void testWrite() throws IOException, InterruptedException {
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
     final AtomicReference<UUID> recordId = new AtomicReference<>();
     withTimeout(new AsyncAction() {
       @Override
@@ -430,7 +422,7 @@ public class ClientTest {
 
   @Test
   public void testPaging() throws InterruptedException, IOException {
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
     final AtomicInteger pages = new AtomicInteger(0);
     final AtomicReference<Boolean> done = new AtomicReference<>(false);
     final AtomicLong last = new AtomicLong(-1L);
@@ -492,7 +484,7 @@ public class ClientTest {
 
   @Test
   public void testRecordDataUpdate() throws IOException, InterruptedException {
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
     final String updatedMessage = "Not to put too fine a point on it";
     withTimeout(new AsyncAction() {
       @Override
@@ -523,7 +515,7 @@ public class ClientTest {
 
   @Test
   public void testRecordDataCustomUpdateMetaClass() throws IOException, InterruptedException {
-    final Client client = getClient().client;
+    final E3DBClient client = getClient().client;
     final String updatedMessage = "Not to put too fine a point on it";
     withTimeout(new AsyncAction() {
       @Override
@@ -573,7 +565,7 @@ public class ClientTest {
 
   @Test
   public void testPlaintextMetaUpdate() throws InterruptedException, IOException {
-    final AtomicReference<Client> clientRef = new AtomicReference<>();
+    final AtomicReference<E3DBClient> clientRef = new AtomicReference<>();
     final AtomicReference<Record> recordRef = new AtomicReference<>();
     registerProfile(UUID.randomUUID().toString(), new ResultHandler<Config>() {
       @Override
@@ -863,7 +855,7 @@ public class ClientTest {
 
   @Test
   public void testWritePlain() throws InterruptedException, IOException {
-    final AtomicReference<Client> clientRef = new AtomicReference<>();
+    final AtomicReference<E3DBClient> clientRef = new AtomicReference<>();
     Map<String, String> poem = new HashMap<>();
     poem.put("line", "All mimsy were the borogoves,");
     final RecordData data = new RecordData(poem);
@@ -977,7 +969,7 @@ public class ClientTest {
   @Test
   public void testEncryptDecrypt() throws IOException, E3DBException {
     CI clientInfo = getClient();
-    final Client client = clientInfo.client;
+    final E3DBClient client = clientInfo.client;
     final String type = UUID.randomUUID().toString() + "-type";
     final AtomicReference<EAKInfo> eakInfoRef = new AtomicReference<>();
     withTimeout(new AsyncAction() {
@@ -1021,14 +1013,14 @@ public class ClientTest {
   @Test
   public void testEncryptDecryptTwoClients() throws IOException, E3DBException {
     CI clientInfo1 = getClient();
-    final Client client1 = clientInfo1.client;
+    final E3DBClient client1 = clientInfo1.client;
     final String type = UUID.randomUUID().toString() + "-type";
     final AtomicReference<EAKInfo> writerKeyRef = new AtomicReference<>();
 
     final String client2Name = UUID.randomUUID().toString();
     registerProfile(client2Name, null);
     CI clientInfo2 = getClient(client2Name);
-    final Client client2 = clientInfo2.client;
+    final E3DBClient client2 = clientInfo2.client;
 
     withTimeout(new AsyncAction() {
       @Override
@@ -1098,7 +1090,7 @@ public class ClientTest {
   @Test
   public void testSigning() throws IOException {
     final CI clientInfo1 = getClient();
-    final Client client = clientInfo1.client;
+    final E3DBClient client = clientInfo1.client;
     final String recordType = "lyric";
     final Map<String, String> data = new HashMap<>();
     data.put("Jabberwock", "Not to put too fine a point on it");
@@ -1158,7 +1150,7 @@ public class ClientTest {
   @Test
   public void testExternalEncryptedRecord() throws IOException {
     final CI clientInfo1 = getClient();
-    final Client client = clientInfo1.client;
+    final E3DBClient client = clientInfo1.client;
     final JsonNode extEncryptedRecord = mapper.readTree("{\"doc\":{\"data\":{\"test_field\":\"QWfE7PpAjTgih1E9jyqSGex32ouzu1iF3la8fWNO5wPp48U2F5Q6kK41_8hgymWn.HW-dBzttfU6Xui-o01lOdVqchXJXqfqQ.eo8zE8peRC9qSt2ZOE8_54kOF0bWBEovuZ4.zO56Or0Pu2IFSzQZRpuXLeinTHQl7g9-\"},\"meta\":{\"plain\":{\"client_pub_sig_key\":\"fcyEKo6HSZo9iebWAQnEemVfqpTUzzR0VNBqgJJG-LY\",\"server_sig_of_client_sig_key\":\"ZtmkUb6MJ-1LqpIbJadYl_PPH5JjHXKrBspprhzaD8rKM4ejGD8cJsSFO1DlR-r7u-DKsLUk82EJF65RnTmMDQ\"},\"type\":\"ticket\",\"user_id\":\"d405a1ce-e528-4946-8682-4c2369a26604\",\"writer_id\":\"d405a1ce-e528-4946-8682-4c2369a26604\"},\"rec_sig\":\"YsNbSXy0mVqsvgArmdESe6SkTAWFui8_NBn8ZRyxBfQHmJt7kwDU6szEqiRIaoZGrHsqgwS3uduLo_kzG6UeCA\"},\"sig\":\"iYc7G6ersNurZRr7_lWqoilr8Ve1d6HPZPPyC4YMXSvg7QvpUAHvjv4LsdMMDthk7vsVpoR0LYPC_SkIip7XCw\"}");
     final JsonNode doc = extEncryptedRecord.get("doc");
     final EncryptedRecord record = LocalEncryptedRecord.decode(mapper.writeValueAsString(doc));
@@ -1179,7 +1171,7 @@ public class ClientTest {
   @Test
   public void testEncryptSigning() throws IOException {
     final CI clientInfo1 = getClient();
-    final Client client = clientInfo1.client;
+    final E3DBClient client = clientInfo1.client;
     final String recordType = "lyric";
     final Map<String, String> plain = new HashMap<>();
     plain.put("frabjous", "Filibuster vigilantly");
@@ -1221,7 +1213,7 @@ public class ClientTest {
   @Test
   public void testEncodeDecodeLocal() throws IOException, E3DBException {
     final CI clientInfo1 = getClient();
-    final Client client = clientInfo1.client;
+    final E3DBClient client = clientInfo1.client;
     final String recordType = "signedLyric";
     final AtomicReference<EAKInfo> eak = new AtomicReference<>();
 
@@ -1344,8 +1336,8 @@ public class ClientTest {
 
   @Test
   public void testEncodeDecodeWrite() throws IOException, E3DBException {
-    final AtomicReference<Client> client1 = new AtomicReference<>();
-    final AtomicReference<Client> client2 = new AtomicReference<>();
+    final AtomicReference<E3DBClient> client1 = new AtomicReference<>();
+    final AtomicReference<E3DBClient> client2 = new AtomicReference<>();
     final AtomicReference<EAKInfo> writerEak = new AtomicReference<>();
     final AtomicReference<EAKInfo> readerEak = new AtomicReference<>();
     final String recordType = "signedLyric";
@@ -1500,7 +1492,7 @@ public class ClientTest {
   @Test
   public void testEAK() throws IOException, E3DBException {
     final CI clientInfo1 = getClient();
-    final Client client = clientInfo1.client;
+    final E3DBClient client = clientInfo1.client;
     final String type = UUID.randomUUID().toString();
     final AtomicReference<LocalEAKInfo> info = new AtomicReference<>();
 

--- a/e3db/src/main/java/com/tozny/e3db/Client.java
+++ b/e3db/src/main/java/com/tozny/e3db/Client.java
@@ -997,6 +997,8 @@ public class Client implements E3DBClient {
     register(token, clientName, publicKey, publicSignKey, host, client, handleResult);
   }
 
+
+
   /**
    * Abstract helper method to enable registration with a pre-configured client instance.
    *
@@ -1063,6 +1065,11 @@ public class Client implements E3DBClient {
         }
       }
     });
+  }
+
+  @Override
+  public E3DBRegistrationClient registrationClient() {
+    return new RegistrationClient();
   }
 
   @Override

--- a/e3db/src/main/java/com/tozny/e3db/Client.java
+++ b/e3db/src/main/java/com/tozny/e3db/Client.java
@@ -70,119 +70,10 @@ import static com.tozny.e3db.Base64.encodeURL;
 import static com.tozny.e3db.Checks.*;
 
 /**
- * Implements interactions with E3DB.
- *
- * <p>This class provides all communication with E3DB. Use it to read, write, update, delete and
- * query records. It can also be used to add and remove sharing rules (through the {@code share} and {@code revoke}
- * methods).
- *
- * <h1>Asynchronous Result Handling</h1>
- * Most methods in this class have a {@code void} return type, and instead return results via a callback argument of type {@link ResultHandler}.
- * All E3DB network communication occurs on a background thread (created by the class). Results are delivered via the callback argument given. On Android,
- * results are delivered on the UI thread. On all other platforms, results are delivered on the same background thread that performed the E3DB operation.
- *
- * <p>Note that no E3DB operations have a defined timeout &mdash; your application is responsible for setting timeouts and performing appropriate action.
- *
- * <h2><i>ResultHandler</i> &amp; <i>Result</i> Values</h2>
- * The {@link ResultHandler} callback accepts a {@link Result} value, which signals whether an error occurred or if the operation completed
- * successfully. The {@link Result#isError()} method will return {@code true} if some error
- * occurred. If not, {@link Result#asValue()} will give the value of the operation that occurred.
- *
- * <p>More details are available on the documentation for {@link Result}.
- *
- * <h1>Registering a Client</h1>
- * Registration requires a "token," which associates each
- * client with your Tozny account. Before using the SDK, go to <a href="https://console.tozny.com">https://console.tozny.com</a>,
- * create an account, and go to
- * the "Manage Clients" section. Click the "Create Token" button under
- * the "Client Registration Tokens" heading. Use the token value created to register
- * new clients. Note that this value is not
- * meant to be secret and is safe to embed in your app.
- *
- * <p>The {@link #register(String, String, String, ResultHandler)} method can be used to
- * register a client. After registration, save the resulting credentials for use later.
- *
- * <h1>Creating a Client</h1>
- * Use the {@link ClientBuilder} class to create a {@link Client} instance from stored credentials. The
- * convenience method {@link ClientBuilder#fromConfig(Config)} makes it easy to load all client
- * information from one location. The
- * {@link Config} class also provides methods for converting credentials to and from JSON.
- *
- * <p>However, <b>ALWAYS</b> be sure to store client credentials securely. Those are the username,
- * password, and private key used by the {@link Client} instance!
- *
- * <h1>Write, Update and Delete Records</h1>
- *
- * Records can be written with the {@link #write(String, RecordData, Map, ResultHandler)} method,
- * updated with {@link #update(UpdateMeta, RecordData, Map, ResultHandler)}, and deleted with {@link #delete(UUID, String, ResultHandler)}.
- *
- * <h1>Reading &amp; Querying Records</h1>
- *
- * You can read a single record with the {@link #read(UUID, ResultHandler)} method.
- *
- * <p>Multiple records (matching some criteria) can be read using the {@link #query(QueryParams, ResultHandler)} method. You must pass a {@link QueryParams} instance
- * to specify the selection critera for records; use the {@link QueryParamsBuilder} object to build the query.
- *
- * <h2>Pagination</h2>
- * Query result pagination depends on the {@link QueryResponse#last()} value, which returns an index indicating the last record
- * in a given page of results. Pass the {@code last()} value obtained to the {@link QueryParamsBuilder#setAfter}) method to
- * obtain records following the last record.
- *
- * <h1>Sharing</h1>
- * Sharing allows one client to give read access to a set of that client's records to another client, without compromising end-to-end encryption. To share
- * records, a client must know the ID of the client they wish to share with. The SDK does not provide support for looking up client IDs - you will have to
- * implement such support out of band.
- *
- * <p>To share records, use the {@link #share(String, UUID, ResultHandler)} method. To remove sharing access, use the {@link #revoke(String, UUID, ResultHandler)}} method.
- *
- * <h1>Local Encryption &amp; Decryption</h1>
- * The client instance has the ability to encrypt records for local storage, and to decrypt locally-stored records. Locally-encrypted records are
- * always encrypted with a key that can be shared with other clients via E3DB's sharing mechanism.
- *
- * <p>Local encryption (and decryption) requires two steps:
- *
- * <oL>
- *   <li>Create a 'writer key' (for encryption) or obtain a 'reader key' (for decryption).</li>
- *  <li>Call {@link #encryptRecord(String, RecordData, Map, EAKInfo)} (for a new document) or {@link #encryptExisting(LocalRecord, EAKInfo)}
- *  (for an existing {@link LocalRecord} instance); for decryption, call {@link #decryptExisting(EncryptedRecord, EAKInfo)}.</li>
- * </ol>
- *
- * <h1>Obtaining A Key for Local Encryption &amp; Decryption</h1>
- *
- * A writer key can be created by calling {@link #createWriterKey(String, ResultHandler)}; a 'reader key' can be obtained by calling
- * {@link #getReaderKey(UUID, UUID, String, ResultHandler)}. (Note that the client calling {@code getReaderKey} will only receive a key if the writer
- * of those records has given access to the calling client through the `share` operation.)
- *
- * <p>The 'writer key' and 'reader key' returned from the client are both {@link LocalEAKInfo} objects (an implementation of the {@link EAKInfo} interface), which can be persisted to storage via the {@link LocalEAKInfo#encode()}
- * method. Previously-persisted keys can be parsed using the {@link LocalEAKInfo#decode(String)} method.
- *
- * <p>However, note that {@code EAKInfo} objects are encrypted with the client's private key, meaning they cannot be decoded by any other client.
- *
- * <h1>Storing Encrypted Records Locally</h1>
- *
- * Use the {@link LocalEncryptedRecord#encode()} method to convert an encrypted record to a string for storage. You can use
- * the {@link LocalEncryptedRecord#decode(String)} method to convert an encoded record back to an {@code EncryptedRecord}
- * instance.
- *
- * <h1>Document Signing &amp; Verification</h1>
- *
- * <p>Every E3DB client created with this SDK is capable of signing
- * documents and verifying the signature associated with a document.
- * By attaching signatures to documents, clients can be confident in:
- *
- * <ul>
- *   <li>Document integrity - the document's contents have not been altered (because the signature will not match).</li>
- *   <li>Proof-of-authorship - The author of the document held the private signing key associated with the given public key
- *       when the document was created.</li>
- * </ul>
- *
- * <p>Use the {@link #sign(Signable)} method to sign a document. Note that {@link Record}, {@link LocalEncryptedRecord}, and {@link LocalRecord}
- * all implement the {@link Signable} interface, and thus can be signed.
- *
- * To verify a signed document, use the {@link #verify(SignedDocument, String)} method. Note that the {@link LocalEncryptedRecord} class
- * implements {@link SignedDocument} and thus always has a signature attached that can be verified.
+ * Implements interactions with E3DB. See {@link E3DBClient} for an introduction, including
+ * registering a client.
  */
-public class  Client {
+public class Client implements E3DBClient {
   private static final ObjectMapper mapper;
   private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
   private static final SimpleDateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
@@ -1000,6 +891,7 @@ public class  Client {
    *
    * @return clientId.
    */
+  @Override
   public UUID clientId() {
     return clientId;
   }
@@ -1173,14 +1065,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Write a new record.
-   *
-   * @param type Describes the type of the record (e.g., "contact_info", "credit_card", etc.).
-   * @param fields Values to encrypt and store.
-   * @param plain Additional, user-defined metadata that will <b>NOT</b> be encrypted. Can be null.
-   * @param handleResult Result of the operation. If successful, returns the newly written record .
-   */
+  @Override
   public void write(final String type, final RecordData fields, final Map<String, String> plain, final ResultHandler<Record> handleResult) {
     checkNotEmpty(type, "type");
     checkNotNull(fields, "fields");
@@ -1226,27 +1111,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Replace the given record with new data and plaintext metadata.
-   *
-   * <p>The {@code updateMeta} argument is only used to obtain
-   * information about the record to replace. No metadata updates by
-   * the client are allowed.
-   * @param updateMeta Metadata describing the record to update. Can be obtained
-   *                   from an existing {@link RecordMeta} instance using {@link LocalUpdateMeta#fromRecordMeta(RecordMeta)}.
-   * @param fields Field names and values. Wrapped in a {@link
-   *               RecordData} instance to prevent confusing with the
-   *               {@code plain} parameter.
-   * @param plain Any metadata associated with the record that will
-   *              <b>NOT</b> be encrypted. If {@code null}, existing
-   *              metadata will be removed.
-   * @param handleResult If the update succeeds, returns the updated
-   *                     record. If the update fails due to a version
-   *                     conflict, the value passed to the {@link
-   *                     ResultHandler#handle(Result)}} method return
-   *                     an instance of {@link E3DBVersionException}
-   *                     when {@code asError().error()} is called.
-   */
+  @Override
   public void update(final UpdateMeta updateMeta, final RecordData fields, final Map<String, String> plain, final ResultHandler<Record> handleResult) {
     checkNotNull(updateMeta, "updateMeta");
     checkNotNull(fields, "fields");
@@ -1299,14 +1164,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Deletes a given record.
-   *
-   * @param recordId ID of the record to delete. Obtained from {@link RecordMeta#recordId()}.
-   * @param version Version associated with the record. Obtained from {@link RecordMeta#version()}.
-   * @param handleResult If the deletion succeeds, returns no useful information. If the delete fails due to a version conflict, the value passed to the {@link ResultHandler#handle(Result)}} method return an instance of
-   * {@link E3DBVersionException} when {@code asError().error()} is called.
-   */
+  @Override
   public void delete(final UUID recordId, final String version, final ResultHandler<Void> handleResult) {
     checkNotNull(recordId, "recordId");
     checkNotEmpty(version, "version");
@@ -1331,13 +1189,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Read a record.
-   *
-   * @param recordId ID of the record to read. Especially useful with {@code query} results that do not include
-   *                 the actual data.
-   * @param handleResult If successful, return the record read.
-   */
+  @Override
   public void read(final UUID recordId, final ResultHandler<Record> handleResult) {
     checkNotNull(recordId, "recordId");
     onBackground(new Runnable() {
@@ -1373,16 +1225,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Get a list of records matching some criteria.
-   *
-   * <p>By default, results are limited to 50 records and do not include encrypted data (a separate
-   * read must be made to get the data for a record).
-   *
-   * @param params The criteria to filter records by. Use the {@link QueryParamsBuilder} class to make this object.
-   * @param handleResult If successful, returns a page of results. The {@link QueryResponse#last()} method can be used
-   *                     in conjunction with the {@link QueryParamsBuilder#setAfter(long)} method to implement pagination.
-   */
+  @Override
   public void query(final QueryParams params, final ResultHandler<QueryResponse> handleResult) {
     checkNotNull(params, "params");
 
@@ -1400,17 +1243,8 @@ public class  Client {
       }
     });
   }
-  /**
-   * Give another client the ability to read records.
-   *
-   * <p>This operation gives read access for records of {@code type}, written by this client, to the
-   * the recipient specified by {@code readerId}.
-   *
-   * @param type The type of records to grant access to.
-   * @param readerId ID of client to give access to.
-   * @param handleResult If successful, returns no useful information (except that the operation
-   *                     completed).
-   */
+
+  @Override
   public void share(final String type, final UUID readerId, final ResultHandler<Void> handleResult) {
     checkNotEmpty(type, "type");
     checkNotNull(readerId, "readerId");
@@ -1456,17 +1290,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Remove permission for another client to read records.
-   *
-   * <p>This operation removes previously granted permission for the client specified by {@code readerId} to
-   * read records, written by this client, of type {@code type}.
-   *
-   * @param type The type of records to remove access to.
-   * @param readerId ID of client to remove access from.
-   * @param handleResult If successful, returns no useful information (except that the operation
-   *                     completed).
-   */
+  @Override
   public void revoke(final String type, final UUID readerId, final ResultHandler<Void> handleResult) {
     checkNotEmpty(type, "type");
     checkNotNull(readerId, "readerId");
@@ -1493,13 +1317,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Get a list of record types shared with this client.
-   *
-   * <p>This operation lists all record types shared with this client, as well as the client (writer)
-   * sharing those records.
-   * @param handleResult If successful, returns a list of records types shared with this client. The resulting list may be empty but never null.
-   */
+  @Override
   public void getIncomingSharing(final ResultHandler<List<IncomingSharingPolicy>> handleResult) {
     onBackground(new Runnable() {
       @Override
@@ -1530,13 +1348,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Get a list of record types shared by this client.
-   *
-   * <p>This operation returns a list of record types shared by this client, including the
-   * client (reader) that the records are shared with.
-   * @param handleResult If successful, returns a list of record types that this client has shared. The resulting list may be empty but will never be null.
-   */
+  @Override
   public void getOutgoingSharing(final ResultHandler<List<OutgoingSharingPolicy>> handleResult) {
     onBackground(new Runnable() {
       @Override
@@ -1567,12 +1379,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Creates (or retrieves) a key that can be used to locally encrypt records.
-   *
-   * @param type Type of the records to encrypt.
-   * @param handleResult Handle the LocalEAKInfo object retrieved.
-   */
+  @Override
   public void createWriterKey(final String type, final ResultHandler<LocalEAKInfo> handleResult) {
     onBackground(new Runnable() {
       @Override
@@ -1603,13 +1410,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Retrieve a key for reading a shared record.
-   * @param writerId ID of the client that wrote the record.
-   * @param userId ID of the user associated with the record (normally equal to {@code writerId}).
-   * @param type Type of record that was shared.
-   * @param handleResult Handle the LocalEAKInfo object retrieved.
-   */
+  @Override
   public void getReaderKey(final UUID writerId, final UUID userId, final String type, final ResultHandler<LocalEAKInfo> handleResult) {
     onBackground(new Runnable() {
       @Override
@@ -1628,14 +1429,7 @@ public class  Client {
     });
   }
 
-  /**
-   * Decrypt a locally-encrypted record.
-   *
-   * @param record The record to decrypt.
-   * @param eakInfo The key to use for decrypting.
-   * @throws E3DBVerificationException Thrown when verification of the signature fails.
-   * @return The decrypted record.
-   */
+  @Override
   public LocalRecord decryptExisting(EncryptedRecord record, EAKInfo eakInfo) throws E3DBVerificationException {
     if (eakInfo.getSignerSigningKey() == null || eakInfo.getSignerSigningKey().isEmpty())
       throw new IllegalStateException("eakInfo cannot be used to verify the record as it has no public signing key.");

--- a/e3db/src/main/java/com/tozny/e3db/ClientBuilder.java
+++ b/e3db/src/main/java/com/tozny/e3db/ClientBuilder.java
@@ -183,7 +183,7 @@ public class ClientBuilder {
    *
    * @return a configured client.
    */
-  public E3DBClient build() {
+  public Client build() {
     checkState();
     if (certificatePinner == null)
       return new Client(apiKey, apiSecret, clientId, host, privateKey, privateSigningKey);

--- a/e3db/src/main/java/com/tozny/e3db/ClientBuilder.java
+++ b/e3db/src/main/java/com/tozny/e3db/ClientBuilder.java
@@ -20,10 +20,8 @@
 
 package com.tozny.e3db;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
 
@@ -181,11 +179,11 @@ public class ClientBuilder {
   }
 
   /**
-   * Create an E3DB Client instance based on configured parameters.
+   * Create an E3DB client based on configured parameters.
    *
-   * @return a configured Client instance.
+   * @return a configured client.
    */
-  public Client build() {
+  public E3DBClient build() {
     checkState();
     if (certificatePinner == null)
       return new Client(apiKey, apiSecret, clientId, host, privateKey, privateSigningKey);

--- a/e3db/src/main/java/com/tozny/e3db/E3DBClient.java
+++ b/e3db/src/main/java/com/tozny/e3db/E3DBClient.java
@@ -305,4 +305,13 @@ public interface E3DBClient {
    * @return {@code true} if the signature matches; {@code false} otherwise.
    */
   boolean verify(SignedDocument signedDocument, String publicSigningKey);
+
+  /**
+   * Return a client capable of registering other clients.
+   *
+   * Intended for mocking the E3DB client when the static {@link Client#register(String, String, String, ResultHandler)}
+   * methods are problematic. Usually, prefer those methods.
+   * @return
+   */
+  E3DBRegistrationClient registrationClient();
 }

--- a/e3db/src/main/java/com/tozny/e3db/E3DBClient.java
+++ b/e3db/src/main/java/com/tozny/e3db/E3DBClient.java
@@ -1,0 +1,308 @@
+package com.tozny.e3db;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Defines interactions with E3DB, excepting registration.
+ *
+ * <p>This interface defines all communication with E3DB. Use it to read, write, update, delete and
+ * query records. It can also be used to add and remove sharing rules (through the {@code share} and {@code revoke}
+ * methods).
+ *
+ * <h1>Asynchronous Result Handling</h1>
+ * Most methods in this class have a {@code void} return type, and instead return results via a callback argument of type {@link ResultHandler}.
+ * All E3DB network communication occurs on a background thread (created by the class). Results are delivered via the callback argument given. On Android,
+ * results are delivered on the UI thread. On all other platforms, results are delivered on the same background thread that performed the E3DB operation.
+ *
+ * <p>Note that no E3DB operations have a defined timeout &mdash; your application is responsible for setting timeouts and performing appropriate action.
+ *
+ * <h2><i>ResultHandler</i> &amp; <i>Result</i> Values</h2>
+ * The {@link ResultHandler} callback accepts a {@link Result} value, which signals whether an error occurred or if the operation completed
+ * successfully. The {@link Result#isError()} method will return {@code true} if some error
+ * occurred. If not, {@link Result#asValue()} will give the value of the operation that occurred.
+ *
+ * <p>More details are available on the documentation for {@link Result}.
+ *
+ * <h1>Registering a Client</h1>
+ * Registration requires a "token," which associates each
+ * client with your Tozny account. Before using the SDK, go to <a href="https://console.tozny.com">https://console.tozny.com</a>,
+ * create an account, and go to
+ * the "Manage Clients" section. Click the "Create Token" button under
+ * the "Client Registration Tokens" heading. Use the token value created to register
+ * new clients. Note that this value is not
+ * meant to be secret and is safe to embed in your app.
+ *
+ * <p>The {@link Client#register(String, String, String, ResultHandler)} method can be used to
+ * register a client. After registration, save the resulting credentials for use later.
+ *
+ * <h1>Creating a Client</h1>
+ * Use the {@link ClientBuilder} class to create a {@link Client} instance from stored credentials. The
+ * convenience method {@link ClientBuilder#fromConfig(Config)} makes it easy to load all client
+ * information from one location. The
+ * {@link Config} class also provides methods for converting credentials to and from JSON.
+ *
+ * <p>However, <b>ALWAYS</b> be sure to store client credentials securely. Those are the username,
+ * password, and private key used by the {@link Client} instance!
+ *
+ * <h1>Write, Update and Delete Records</h1>
+ *
+ * Records can be written with the {@link #write(String, RecordData, Map, ResultHandler)} method,
+ * updated with {@link #update(UpdateMeta, RecordData, Map, ResultHandler)}, and deleted with {@link #delete(UUID, String, ResultHandler)}.
+ *
+ * <h1>Reading &amp; Querying Records</h1>
+ *
+ * You can read a single record with the {@link #read(UUID, ResultHandler)} method.
+ *
+ * <p>Multiple records (matching some criteria) can be read using the {@link #query(QueryParams, ResultHandler)} method. You must pass a {@link QueryParams} instance
+ * to specify the selection critera for records; use the {@link QueryParamsBuilder} object to build the query.
+ *
+ * <h2>Pagination</h2>
+ * Query result pagination depends on the {@link QueryResponse#last()} value, which returns an index indicating the last record
+ * in a given page of results. Pass the {@code last()} value obtained to the {@link QueryParamsBuilder#setAfter}) method to
+ * obtain records following the last record.
+ *
+ * <h1>Sharing</h1>
+ * Sharing allows one client to give read access to a set of that client's records to another client, without compromising end-to-end encryption. To share
+ * records, a client must know the ID of the client they wish to share with. The SDK does not provide support for looking up client IDs - you will have to
+ * implement such support out of band.
+ *
+ * <p>To share records, use the {@link #share(String, UUID, ResultHandler)} method. To remove sharing access, use the {@link #revoke(String, UUID, ResultHandler)}} method.
+ *
+ * <h1>Local Encryption &amp; Decryption</h1>
+ * The client instance has the ability to encrypt records for local storage, and to decrypt locally-stored records. Locally-encrypted records are
+ * always encrypted with a key that can be shared with other clients via E3DB's sharing mechanism.
+ *
+ * <p>Local encryption (and decryption) requires two steps:
+ *
+ * <oL>
+ *   <li>Create a 'writer key' (for encryption) or obtain a 'reader key' (for decryption).</li>
+ *  <li>Call {@link #encryptRecord(String, RecordData, Map, EAKInfo)} (for a new document) or {@link #encryptExisting(LocalRecord, EAKInfo)}
+ *  (for an existing {@link LocalRecord} instance); for decryption, call {@link #decryptExisting(EncryptedRecord, EAKInfo)}.</li>
+ * </ol>
+ *
+ * <h1>Obtaining A Key for Local Encryption &amp; Decryption</h1>
+ *
+ * A writer key can be created by calling {@link #createWriterKey(String, ResultHandler)}; a 'reader key' can be obtained by calling
+ * {@link #getReaderKey(UUID, UUID, String, ResultHandler)}. (Note that the client calling {@code getReaderKey} will only receive a key if the writer
+ * of those records has given access to the calling client through the `share` operation.)
+ *
+ * <p>The 'writer key' and 'reader key' returned from the client are both {@link LocalEAKInfo} objects (an implementation of the {@link EAKInfo} interface), which can be persisted to storage via the {@link LocalEAKInfo#encode()}
+ * method. Previously-persisted keys can be parsed using the {@link LocalEAKInfo#decode(String)} method.
+ *
+ * <p>However, note that {@code EAKInfo} objects are encrypted with the client's private key, meaning they cannot be decoded by any other client.
+ *
+ * <h1>Storing Encrypted Records Locally</h1>
+ *
+ * Use the {@link LocalEncryptedRecord#encode()} method to convert an encrypted record to a string for storage. You can use
+ * the {@link LocalEncryptedRecord#decode(String)} method to convert an encoded record back to an {@code EncryptedRecord}
+ * instance.
+ *
+ * <h1>Document Signing &amp; Verification</h1>
+ *
+ * <p>Every E3DB client created with this SDK is capable of signing
+ * documents and verifying the signature associated with a document.
+ * By attaching signatures to documents, clients can be confident in:
+ *
+ * <ul>
+ *   <li>Document integrity - the document's contents have not been altered (because the signature will not match).</li>
+ *   <li>Proof-of-authorship - The author of the document held the private signing key associated with the given public key
+ *       when the document was created.</li>
+ * </ul>
+ *
+ * <p>Use the {@link #sign(Signable)} method to sign a document. Note that {@link Record}, {@link LocalEncryptedRecord}, and {@link LocalRecord}
+ * all implement the {@link Signable} interface, and thus can be signed.
+ *
+ * To verify a signed document, use the {@link #verify(SignedDocument, String)} method. Note that the {@link LocalEncryptedRecord} class
+ * implements {@link SignedDocument} and thus always has a signature attached that can be verified.
+ */
+public interface E3DBClient {
+  /**
+   * The ID of this client.
+   *
+   * @return clientId.
+   */
+  UUID clientId();
+
+  /**
+   * Write a new record.
+   *
+   * @param type Describes the type of the record (e.g., "contact_info", "credit_card", etc.).
+   * @param fields Values to encrypt and store.
+   * @param plain Additional, user-defined metadata that will <b>NOT</b> be encrypted. Can be null.
+   * @param handleResult Result of the operation. If successful, returns the newly written record .
+   */
+  void write(String type, RecordData fields, Map<String, String> plain, ResultHandler<Record> handleResult);
+
+  /**
+   * Replace the given record with new data and plaintext metadata.
+   *
+   * <p>The {@code updateMeta} argument is only used to obtain
+   * information about the record to replace. No metadata updates by
+   * the client are allowed.
+   * @param updateMeta Metadata describing the record to update. Can be obtained
+   *                   from an existing {@link RecordMeta} instance using {@link LocalUpdateMeta#fromRecordMeta(RecordMeta)}.
+   * @param fields Field names and values. Wrapped in a {@link
+   *               RecordData} instance to prevent confusing with the
+   *               {@code plain} parameter.
+   * @param plain Any metadata associated with the record that will
+   *              <b>NOT</b> be encrypted. If {@code null}, existing
+   *              metadata will be removed.
+   * @param handleResult If the update succeeds, returns the updated
+   *                     record. If the update fails due to a version
+   *                     conflict, the value passed to the {@link
+   *                     ResultHandler#handle(Result)}} method return
+   *                     an instance of {@link E3DBVersionException}
+   *                     when {@code asError().error()} is called.
+   */
+  void update(UpdateMeta updateMeta, RecordData fields, Map<String, String> plain, ResultHandler<Record> handleResult);
+
+  /**
+   * Deletes a given record.
+   *
+   * @param recordId ID of the record to delete. Obtained from {@link RecordMeta#recordId()}.
+   * @param version Version associated with the record. Obtained from {@link RecordMeta#version()}.
+   * @param handleResult If the deletion succeeds, returns no useful information. If the delete fails due to a version conflict, the value passed to the {@link ResultHandler#handle(Result)}} method return an instance of
+   * {@link E3DBVersionException} when {@code asError().error()} is called.
+   */
+  void delete(UUID recordId, String version, ResultHandler<Void> handleResult);
+
+  /**
+   * Read a record.
+   *
+   * @param recordId ID of the record to read. Especially useful with {@code query} results that do not include
+   *                 the actual data.
+   * @param handleResult If successful, return the record read.
+   */
+  void read(UUID recordId, ResultHandler<Record> handleResult);
+
+  /**
+   * Get a list of records matching some criteria.
+   *
+   * <p>By default, results are limited to 50 records and do not include encrypted data (a separate
+   * read must be made to get the data for a record).
+   *
+   * @param params The criteria to filter records by. Use the {@link QueryParamsBuilder} class to make this object.
+   * @param handleResult If successful, returns a page of results. The {@link QueryResponse#last()} method can be used
+   *                     in conjunction with the {@link QueryParamsBuilder#setAfter(long)} method to implement pagination.
+   */
+  void query(QueryParams params, ResultHandler<QueryResponse> handleResult);
+
+  /**
+   * Give another client the ability to read records.
+   *
+   * <p>This operation gives read access for records of {@code type}, written by this client, to the
+   * the recipient specified by {@code readerId}.
+   *
+   * @param type The type of records to grant access to.
+   * @param readerId ID of client to give access to.
+   * @param handleResult If successful, returns no useful information (except that the operation
+   *                     completed).
+   */
+  void share(String type, UUID readerId, ResultHandler<Void> handleResult);
+
+  /**
+   * Remove permission for another client to read records.
+   *
+   * <p>This operation removes previously granted permission for the client specified by {@code readerId} to
+   * read records, written by this client, of type {@code type}.
+   *
+   * @param type The type of records to remove access to.
+   * @param readerId ID of client to remove access from.
+   * @param handleResult If successful, returns no useful information (except that the operation
+   *                     completed).
+   */
+  void revoke(String type, UUID readerId, ResultHandler<Void> handleResult);
+
+  /**
+   * Get a list of record types shared with this client.
+   *
+   * <p>This operation lists all record types shared with this client, as well as the client (writer)
+   * sharing those records.
+   * @param handleResult If successful, returns a list of records types shared with this client. The resulting list may be empty but never null.
+   */
+  void getIncomingSharing(ResultHandler<List<IncomingSharingPolicy>> handleResult);
+
+  /**
+   * Get a list of record types shared by this client.
+   *
+   * <p>This operation returns a list of record types shared by this client, including the
+   * client (reader) that the records are shared with.
+   * @param handleResult If successful, returns a list of record types that this client has shared. The resulting list may be empty but will never be null.
+   */
+  void getOutgoingSharing(ResultHandler<List<OutgoingSharingPolicy>> handleResult);
+
+  /**
+   * Creates (or retrieves) a key that can be used to locally encrypt records.
+   *
+   * @param type Type of the records to encrypt.
+   * @param handleResult Handle the LocalEAKInfo object retrieved.
+   */
+  void createWriterKey(String type, ResultHandler<LocalEAKInfo> handleResult);
+
+  /**
+   * Retrieve a key for reading a shared record.
+   * @param writerId ID of the client that wrote the record.
+   * @param userId ID of the user associated with the record (normally equal to {@code writerId}).
+   * @param type Type of record that was shared.
+   * @param handleResult Handle the LocalEAKInfo object retrieved.
+   */
+  void getReaderKey(UUID writerId, UUID userId, String type, ResultHandler<LocalEAKInfo> handleResult);
+
+  /**
+   * Decrypt a locally-encrypted record.
+   *
+   * @param record The record to decrypt.
+   * @param eakInfo The key to use for decrypting.
+   * @throws E3DBVerificationException Thrown when verification of the signature fails.
+   * @return The decrypted record.
+   */
+  LocalRecord decryptExisting(EncryptedRecord record, EAKInfo eakInfo) throws E3DBVerificationException;
+
+  /**
+   * Sign &amp; encrypt an existing record for local storage.
+   *
+   * @param record The record to encrypt.
+   * @param eakInfo The key to use for encrypting.
+   * @return The encrypted record.
+   */
+  LocalEncryptedRecord encryptExisting(LocalRecord record, EAKInfo eakInfo);
+
+  /**
+   * Sign &amp; encrypt a record for local storage.
+   *
+   * @param type The type of the record.
+   * @param data Fields to encrypt.
+   * @param plain Plaintext metadata which will be stored with the record.
+   * @param eakInfo The key to use for encrypting.
+   * @return The encrypted record.
+   */
+  LocalEncryptedRecord encryptRecord(String type, RecordData data, Map<String, String> plain, EAKInfo eakInfo);
+
+  /**
+   * Derives a signature using this client's private Ed25519 key and the document given.
+   *
+   * @param document The document to sign. Consider using {@link LocalRecord}, which implements the
+   *                 {@link Signable} interface.
+   * @param <T> T.
+   * @return A {@link SignedDocument} instance, holding the document given and a signature
+   * for it.
+   */
+  <T extends Signable> SignedDocument<T> sign(T document);
+
+  /**
+   * Verifies that the signature attached to the document was:
+   *
+   * <ul>
+   * <li>Produced by the holder of the private key associated with the {@code publicSigningKey} given.</li>
+   * <li>Derived from the document given.
+   * </ul>
+   *
+   * @param signedDocument Document and signature to verify.
+   * @param publicSigningKey Public portion of the Ed25519 key used to produce the signature, as a Base64URL-encoded
+   *                         string.
+   * @return {@code true} if the signature matches; {@code false} otherwise.
+   */
+  boolean verify(SignedDocument signedDocument, String publicSigningKey);
+}

--- a/e3db/src/main/java/com/tozny/e3db/E3DBRegistrationClient.java
+++ b/e3db/src/main/java/com/tozny/e3db/E3DBRegistrationClient.java
@@ -1,0 +1,32 @@
+package com.tozny.e3db;
+
+import okhttp3.CertificatePinner;
+
+/**
+ * An interface for registration. Should only be used when mocking the E3DB client in unit tests.
+ */
+public interface E3DBRegistrationClient {
+  /**
+   * Registers a new client. This method creates a new public/private key pair for the client
+   * to use when encrypting and decrypting records.
+   *
+   * @param token Registration token obtained from the Tozny console at <a href="https://console.tozny.com">https://console.tozny.com</a>.
+   * @param clientName Name of the client; for informational purposes only.
+   * @param host Host to register with. Should be {@code https://api.e3db.com}.
+   * @param certificatePinner OkHttp CertificatePinner instance to restrict which certificates and authorities are trusted.
+   * @param handleResult Handles the result of registration. The {@link Config} value can be converted to JSON, written to
+   *                     a secure location, and loaded later.
+   */
+  void register(String token, String clientName, String host, CertificatePinner certificatePinner,  ResultHandler<Config> handleResult);
+  /**
+   * Registers a new client. This method creates a new public/private key pair for the client
+   * to use when encrypting and decrypting records.
+   *
+   * @param token Registration token obtained from the Tozny console at <a href="https://console.tozny.com">https://console.tozny.com</a>.
+   * @param clientName Name of the client; for informational purposes only.
+   * @param host Host to register with. Should be {@code https://api.e3db.com}.
+   * @param handleResult Handles the result of registration. The {@link Config} value can be converted to JSON, written to
+   *                     a secure location, and loaded later.
+   */
+  void register( String token,  String clientName,  String host,  ResultHandler<Config> handleResult);
+}

--- a/e3db/src/main/java/com/tozny/e3db/QueryParams.java
+++ b/e3db/src/main/java/com/tozny/e3db/QueryParams.java
@@ -20,7 +20,6 @@
 
 package com.tozny.e3db;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 

--- a/e3db/src/main/java/com/tozny/e3db/RegistrationClient.java
+++ b/e3db/src/main/java/com/tozny/e3db/RegistrationClient.java
@@ -1,0 +1,22 @@
+package com.tozny.e3db;
+
+import okhttp3.CertificatePinner;
+
+/**
+ * A client capable of registering further clients. Intended for mock testing, where the static {@link Client#register(String, String, String, ResultHandler)}
+ * methods are problematic.
+ *
+ * Not for normal use; prefer the static methods.
+ * @return
+ */
+public class RegistrationClient implements E3DBRegistrationClient {
+  @Override
+  public void register(String token, String clientName, String host, CertificatePinner certificatePinner, ResultHandler<Config> handleResult) {
+    Client.register(token, clientName, host, certificatePinner, handleResult);
+  }
+
+  @Override
+  public void register(String token, String clientName, String host, ResultHandler<Config> handleResult) {
+    Client.register(token, clientName, host, handleResult);
+  }
+}

--- a/plaintest/build.gradle
+++ b/plaintest/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   testCompile 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr4'
   testCompile 'com.fasterxml.jackson.core:jackson-annotations:2.9.0.pr4'
   testCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.0.pr4'
+  testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 test {

--- a/plaintest/src/test/java/com/tozny/e3db/MockTests.java
+++ b/plaintest/src/test/java/com/tozny/e3db/MockTests.java
@@ -1,0 +1,15 @@
+package com.tozny.e3db;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+public class MockTests {
+  @Test
+  public void testClient() {
+    E3DBClient c = mock(E3DBClient.class);
+    assertNotNull(c);
+  }
+}

--- a/plaintest/src/test/java/com/tozny/e3db/MockTests.java
+++ b/plaintest/src/test/java/com/tozny/e3db/MockTests.java
@@ -3,6 +3,7 @@ package com.tozny.e3db;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
 
@@ -20,6 +21,8 @@ public class MockTests {
     E3DBClient c = mock(E3DBClient.class);
     when(c.registrationClient()).thenReturn(r);
 
-    assertNotNull(c.registrationClient());
+    E3DBRegistrationClient returnedRegClient = c.registrationClient();
+    assertNotNull(returnedRegClient);
+    assertSame(r, returnedRegClient);
   }
 }

--- a/plaintest/src/test/java/com/tozny/e3db/MockTests.java
+++ b/plaintest/src/test/java/com/tozny/e3db/MockTests.java
@@ -12,4 +12,14 @@ public class MockTests {
     E3DBClient c = mock(E3DBClient.class);
     assertNotNull(c);
   }
+
+  public void testRegistrationClient() {
+    E3DBRegistrationClient r = mock(E3DBRegistrationClient.class);
+    assertNotNull(r);
+
+    E3DBClient c = mock(E3DBClient.class);
+    when(c.registrationClient()).thenReturn(r);
+
+    assertNotNull(c.registrationClient());
+  }
 }

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -19,7 +19,7 @@
  */
 
 ext {
-  version = "3.2.0-SNAPSHOT"
+  version = "3.3.0-SNAPSHOT"
   groupId = "com.tozny.e3db"
   baseName = "e3db-client"
 }


### PR DESCRIPTION
Extracted an interface from the Client class to
make mocking simpler and to avoid static initialization
issues where crypto libraries could not be loaded.

Added test cases and updated documentation.

These changes update the 3.2.0 version of the SDK and will 
be published as 3.3.0 when approved.