### PR TITLE
[BUG] Include All writers uses the wrong param

### DIFF
--- a/e3db/src/main/java/com/tozny/e3db/Client.java
+++ b/e3db/src/main/java/com/tozny/e3db/Client.java
@@ -851,7 +851,7 @@ public class  Client {
       searchRequest.put("writer_ids", makeArray(params.writerIds));
 
     if(params.includeAllWriters != null)
-      searchRequest.put("include_all_writers", params.includeData.booleanValue());
+      searchRequest.put("include_all_writers", params.includeAllWriters.booleanValue());
 
     if(params.userIds != null)
       searchRequest.put("user_ids", makeArray(params.userIds));


### PR DESCRIPTION
- The Search param for IncludeAllWriters was using the IncludeAllData
Value. This causes null pointers to be thrown and makes the
IncludeAllWriters value be ignored