### PR TITLE
[E3DB-1139] Move E3DB Java Hosting to Maven Central

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,7 +167,6 @@ When preparing to publish:
 - Merge all changes that will be published into the master branch.
 - Change the version number in `./publish/build.gradle` to the version that will be published.
 - Make sure all Android lint checks pass (`./gradlew :publish:android:lint`)
-- Publish JARs to the remote repository (`./gradlew :publish:publishRemote`)
 - Tag the commit using the version number just published (`git tag -s -a -m "Release <version>" <version>`)
 - Generate javadocs (`./gradlew :e3db:javadoc`)
 - Commit the newly generated javadocs folder.
@@ -177,12 +176,21 @@ When preparing to publish:
   - docs\index.md - Change link to latest version of docs; move link to previous version of docs to the list of previous versions.
 - Commit changes to documentation
 - Push changes and tags to remote
+- Publish JARs to the remote repository (`./gradlew :publish:publishMavenCentral`)
 
-To publish to an S3 hosted maven repository, the following environment variables must be set:
 
-* `REPO_URL` - URL for the S3 bucket holding maven artifacts (in the form `s3://<bucket>.<region>.amazonaws.com/<dir>`).
-* `AWS_KEY` - Your AWS API key.
-* `AWS_SECRET` - Your AWS API secret.
+To publish to maven central, the following gradle properties must be set:
+
+* signing.keyId= <- last 8 characters of your private signing key, this key must be shared with a third party gpg key server such as hkp://keyserver.ubuntu.com
+* signing.password= <- signing key password
+* signing.secretKeyRingFile= <-full path to your secring.gpg
+  
+* ossrhUsername= <- user token for sonatype ossr account that has permissions to deploy form com.tozny
+* ossrhPassword= <- password token for above account
+  
+* developerId= <developer id>
+* developerName= <Full Name>
+* developerEmail= <tozny email address>
 
 The version published is set in `publish/build.gradle`, in the `ext` block:
 
@@ -193,13 +201,14 @@ ext {
 }
 ```
 
-Assuming your AWS account has the correct privileges, publish by running the following task:
+Assuming your OSSRH account has the correct privileges, publish by running the following task:
 
 ```bash
-$ ./gradlew :publish:publishRemote
+$ ./gradlew :publish:publishMavenCentral
 ```
 
-The task will publish both the plain Java JAR and the Android AAR to the maven repository.
+The task will publish both the plain Java JAR and the Android AAR to the maven staging repository, actual deployment needs to be done with the [Nexus Repository Manager](https://oss.sonatype.org/#stagingRepositories.)
+Instructions for that can be found [here](https://central.sonatype.org/pages/releasing-the-deployment.html)
 
 Writing Android Apps
 ====

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ app, add it as a dependency to your build. In Gradle, use:
 
 ```
 repositories {
-  maven { url "https://maven.tozny.com/repo" }
+  mavenCentral()
   maven { url "https://dl.bintray.com/terl/lazysodium-maven" }
 }
 
@@ -73,17 +73,9 @@ needs to request INTERNET permissions.
 
 # Using the SDK with Plain Java
 
-For use with Maven, declare the following repository and dependencies:
+For use with Maven, declare the following dependencies:
 
 ```
-<repositories>
-  <repository>
-    <id>tozny-repo</id>
-    <name>Tozny Repository</name>
-    <url>https://maven.tozny.com/repo</url>
-  </repository>
-</repositories>
-
 <dependencies>
   <dependency>
     <groupId>com.tozny.e3db</groupId>

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ buildscript {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.30"
         classpath 'digital.wup:android-maven-publish:3.2.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 

--- a/publish/android/build.gradle
+++ b/publish/android/build.gradle
@@ -18,9 +18,14 @@
  *
  */
 
+
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'digital.wup.android-maven-publish'
+
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'signing'
 
 android {
   compileSdkVersion 27
@@ -60,7 +65,25 @@ android {
 evaluationDependsOn(':publish')
 
 task sourceJar(type: Jar) {
+  classifier = 'sources'
   from android.sourceSets.main.java.sourceFiles
+}
+
+
+task javadoc(type: Javadoc) {
+  source = android.sourceSets.main.java.srcDirs
+  classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+  destinationDir = file("../javadoc/")
+  failOnError false
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from javadoc.destinationDir
+}
+
+signing {
+  sign configurations.archives
 }
 
 publishing {
@@ -72,20 +95,6 @@ publishing {
       artifactId 'e3db-client-android'
       version project(":publish").ext.version
 
-      artifact sourceJar {
-        classifier "sources"
-      }
-
-      repositories {
-        maven {
-          // url should be of the form "s3://<bucket>.s3-<region>.amazonaws.com/<folder>"
-          url "${System.getenv('REPO_URL')}"
-          credentials(AwsCredentials) {
-            accessKey "${System.getenv('AWS_KEY')}"
-            secretKey "${System.getenv('AWS_SECRET')}"
-          }
-        }
-      }
     }
   }
 }
@@ -98,5 +107,58 @@ dependencies {
   implementation project(":e3db").configurations.compile.dependencies.matching { dep ->
     // exclude project dependencies - only include external, maven dependencies
     ExternalModuleDependency.class.isAssignableFrom(dep.class)
+  }
+}
+
+artifacts {
+  archives javadocJar, sourceJar
+}
+
+uploadArchives {
+  group = "com.tozny.e3db"
+  archivesBaseName = "e3db-client-android"
+  version = project(":publish").ext.version
+  repositories {
+    mavenDeployer {
+      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+
+      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+      pom.project {
+        artifactId = 'e3db-client-android'
+        groupId = 'com.tozny.e3db'
+        name 'E3DB Java SDK'
+        packaging 'jar'
+        // optionally artifactId can be defined here
+        description 'An SDK to interact with TozStore Encrypted Storage with Android'
+        url 'https://github.com/tozny/e3db-java'
+
+        scm {
+          connection 'scm:git:git://github.com/tozny/e3db-java.git'
+          developerConnection 'scm:git:ssh://github.com/tozny/e3db-java.git'
+          url 'https://github.com/tozny/e3db-java/tree/master'
+        }
+
+        licenses {
+          license {
+            name 'TOZNY NON-COMMERCIAL LICENSE'
+            url 'https://tozny.com/legal/non-commercial-license'
+          }
+        }
+
+        developers {
+          developer {
+            id developerId
+            name developerName
+            email developerEmail
+          }
+        }
+      }
+    }
   }
 }

--- a/publish/build.gradle
+++ b/publish/build.gradle
@@ -30,8 +30,8 @@ task publishLocal(dependsOn: [":publish:android:publishMavenAarPublicationToMave
   }
 }
 
-task publishRemote(dependsOn: [":publish:android:publishMavenAarPublicationToMavenRepository", ":publish:plain:publishMavenPublicationToMavenRepository"]) {
+task publishMavenCentral(dependsOn: [":publish:android:uploadArchives", ":publish:plain:uploadArchives"]) {
   doLast {
-    println "Published remote artifacts."
+    println "Published Artifacts to Nexus Repository Manager"
   }
 }

--- a/publish/plain/build.gradle
+++ b/publish/plain/build.gradle
@@ -22,6 +22,9 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
+apply plugin: 'maven'
+apply plugin: 'signing'
+
 sourceSets {
   main {
     java {
@@ -36,7 +39,17 @@ sourceSets {
 evaluationDependsOn(':publish')
 
 task sourceJar(type: Jar) {
+  classifier = 'sources'
   from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar) {
+  classifier = 'javadoc'
+  from javadoc
+}
+
+signing {
+  sign configurations.archives
 }
 
 publishing {
@@ -44,23 +57,9 @@ publishing {
     maven(MavenPublication) {
       from components.java
 
-      artifact sourceJar {
-        classifier "sources"
-      }
-
       groupId project(":publish").ext.groupId
       artifactId 'e3db-client-plain'
       version project(":publish").ext.version
-    }
-  }
-  repositories {
-    maven {
-      // url should be of the form "s3://<bucket>.s3-<region>.amazonaws.com/<folder>"
-      url "${System.getenv('REPO_URL')}"
-      credentials(AwsCredentials) {
-        accessKey "${System.getenv('AWS_KEY')}"
-        secretKey "${System.getenv('AWS_SECRET')}"
-      }
     }
   }
 }
@@ -75,4 +74,59 @@ dependencies {
     ExternalModuleDependency.class.isAssignableFrom(dep.class)
   }
   compileOnly project(":e3db").configurations.compileOnly.dependencies
+}
+
+
+artifacts {
+  archives javadocJar, sourceJar
+}
+
+uploadArchives {
+  group = "com.tozny.e3db"
+  archivesBaseName = "e3db-client-plain"
+  version = project(":publish").ext.version
+  println()
+  repositories {
+    mavenDeployer {
+      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+
+      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+        authentication(userName: ossrhUsername, password: ossrhPassword)
+      }
+      pom.project {
+        artifactId = 'e3db-client-plain'
+        groupId = 'com.tozny.e3db'
+        name 'E3DB Java SDK'
+        packaging 'jar'
+        // optionally artifactId can be defined here
+        description 'An SDK to interact with TozStore Encrypted Storage'
+        url 'https://github.com/tozny/e3db-java'
+
+        scm {
+          connection 'scm:git:git://github.com/tozny/e3db-java.git'
+          developerConnection 'scm:git:ssh://github.com/tozny/e3db-java.git'
+          url 'https://github.com/tozny/e3db-java/tree/master'
+        }
+
+        licenses {
+          license {
+            name 'TOZNY NON-COMMERCIAL LICENSE'
+            url 'https://tozny.com/legal/non-commercial-license'
+          }
+        }
+
+        developers {
+          developer {
+            id developerId
+            name developerName
+            email developerEmail
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Update gradle publish configurations to publish to Maven Central
- Remove gradle publish configurations to publish to self-hosted maven
- Update README to reflect new process to publish artifacts