### PR TITLE
Bugs/wash 726 Don't swallow exception information

### DIFF
--- a/e3db/src/main/java/com/tozny/e3db/ErrorResult.java
+++ b/e3db/src/main/java/com/tozny/e3db/ErrorResult.java
@@ -71,16 +71,16 @@ public class ErrorResult<R> implements Result<R> {
   /**
    * Returns any E3DB-specific error that occurred.
    *
-   * <p>This method will return {@code null} if a general exception
+   * <p>This method will return the underlying exception if a general exception
    * occurred during the operation; otherwise, it will return a specific E3DB error.
    *
-   * @return The  error, if any.
+   * @return The error, if any.
    */
   public E3DBException error() {
     if(error instanceof E3DBException)
       return (E3DBException) error;
     else
-      return null;
+      return error;
   }
 
   /**


### PR DESCRIPTION
- Resolves instances of [debug logs showing "null" for errors returned from e3db-java](https://toznysecurity.atlassian.net/browse/WASH-726) 

I'm not a Java expert so please yell at me so at least I can know what one sounds like 😂, no but really let me know if there is a more idiomatic way of doing this or if I'm foolish for thinking this will fix the issue.